### PR TITLE
UI tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>OSM Analysis Dashboard</title>
 
-
-
     <!-- Assembly CSS -->
     <link href="https://api.mapbox.com/mapbox-assembly/v0.17.0/assembly.min.css" rel="stylesheet">
 

--- a/script.js
+++ b/script.js
@@ -28,11 +28,11 @@
     });
 
     // Add geocoder
-    var geocoder = new MapboxGeocoder({
-        accessToken: mapboxgl.accessToken
-    });
+    //var geocoder = new MapboxGeocoder({
+    //    accessToken: mapboxgl.accessToken
+    //});
 
-    $('#geocoder').append(geocoder.onAdd(beforeMap));
+    //$('#geocoder').append(geocoder.onAdd(beforeMap));
 
     updateLegendLabels(appState);
 
@@ -348,7 +348,7 @@
         Update the label for the two maps
         And the legend title
     */
-    function updateLegendLabels(props) {        
+    function updateLegendLabels(props) {
         $('#before-label').text(props.startYear);
         $('#after-label').text(props.endYear);
         $('#legend-property').text(props.filterProperty);


### PR DESCRIPTION
Continues #10.

<img width="1278" alt="screenshot 2017-09-20 19 04 40" src="https://user-images.githubusercontent.com/1117531/30646439-a3723a42-9e36-11e7-8b92-368b4023db0f.png">

- [x] Added label on left & right for which Quarter it is
- [ ] PUT BACK Geocoding control
- [x] Move the legend, do not let it merge with map
- [x] Added copy changes
- [x] Center stuff better

@tridip1931 @batpad I’ll need some 👁  to center stuff better.